### PR TITLE
replace skiptest with nottest

### DIFF
--- a/pecos/graphics/plot_test_results.py
+++ b/pecos/graphics/plot_test_results.py
@@ -1,33 +1,38 @@
 import matplotlib.pyplot as plt
 from pecos.graphics import plot_timeseries
 import logging
-from nose.plugins.skip import SkipTest
+
+try:
+    from nose.tools import nottest
+except ImportError:
+    def nottest(afunction):
+        return afunction
 
 logger = logging.getLogger(__name__)
 
-@SkipTest
+@nottest
 def plot_test_results(filename, pm):
     """
-    Create test results graphics.  
+    Create test results graphics.
     Graphics include data that failed a quality control test.
-    
+
     Parameters
     ----------
     filename : string
         Filename root, each graphic is appended with '_pecos_*.jpg' where * is an integer
-    
+
     pm : PerformanceMonitoring object
         Contains data (pm.df) and test results (pm.test_results)
     """
     if pm.test_results.empty:
         return
-    
+
     graphic = 0
-      
+
     tfilter = pm.tfilter
-    
+
     grouped = pm.test_results.groupby(['System Name', 'Variable Name'])
-     
+
     for name, test_results_group in grouped:
         if name[1] == ' ':
             continue
@@ -35,8 +40,8 @@ def plot_test_results(filename, pm):
             col_name = str(name[1])
         else:
             col_name = str(name[0]) + ":" + str(name[1])
-        
-        
+
+
         if test_results_group['Error Flag'].all() in ['Duplicate timestamp', 'Missing data', 'Corrupt data', 'Missing timestamp', 'Nonmonotonic timestamp']:
             continue
         logger.info("Creating graphic for " + col_name)
@@ -46,10 +51,9 @@ def plot_test_results(filename, pm):
         ax = plt.gca()
         box = ax.get_position()
         ax.set_position([box.x0, box.y0, box.width*0.65, box.height])
-        plt.legend(loc='center left', bbox_to_anchor=(1, 0.5), fontsize=8) 
+        plt.legend(loc='center left', bbox_to_anchor=(1, 0.5), fontsize=8)
         plt.title(col_name, fontsize=8)
-       
+
         plt.savefig(filename +'_pecos_'+str(graphic)+'.jpg', format='jpg', dpi=500)
         graphic = graphic + 1
         plt.close()
-        

--- a/pecos/io/write_test_results.py
+++ b/pecos/io/write_test_results.py
@@ -1,28 +1,33 @@
 import numpy as np
 import logging
-from nose.plugins.skip import SkipTest
+
+try:
+    from nose.tools import nottest
+except ImportError:
+    def nottest(afunction):
+        return afunction
 
 logger = logging.getLogger(__name__)
 
-@SkipTest
+@nottest
 def write_test_results(filename, test_results):
     """
     Write test results file
-    
+
     Parameters
     -----------
     filename : string
         Filename with full path
-    
+
     test_results : pd.DataFrame
         Test results stored in pm.test_results
     """
-    
+
     test_results.sort_values(['System Name', 'Variable Name'], inplace=True)
     test_results.index = np.arange(1, test_results.shape[0]+1)
-    
+
     logger.info("Writing test results csv file " + filename)
-    
+
     fout = open(filename, 'w')
     test_results.to_csv(fout, na_rep = 'NaN')
     fout.close()


### PR DESCRIPTION
This PR replaces the ``SkipTest`` decorator on the ``plot_test_results`` and ``write_test_results`` functions with the ``nottest`` decorator. It also defines a pass-through ``nottest`` decorator so that users don't have to install nose in order to run pecos.

It was easy to run the simple example and build the documentation. I ran into some issues with the pv example but didn't look closely at what was causing them. Neat project!