### PR TITLE
fix importerror on py3

### DIFF
--- a/pecos/__init__.py
+++ b/pecos/__init__.py
@@ -1,14 +1,14 @@
-import monitoring
-import metrics
-import io
-import graphics
-import logger
-import utils
+from . import monitoring
+from . import metrics
+from . import io
+from . import graphics
+from . import logger
+from . import utils
 
 __version__ = '0.1'
 
-__copyright__ = """Copyright 2016 Sandia Corporation. 
-Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation, 
+__copyright__ = """Copyright 2016 Sandia Corporation.
+Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
 the U.S. Government retains certain rights in this software."""
 
 __license__ = "Revised BSD License"

--- a/pecos/graphics/__init__.py
+++ b/pecos/graphics/__init__.py
@@ -1,3 +1,3 @@
-from plot_scatter import plot_scatter
-from plot_timeseries import plot_timeseries
-from plot_test_results import plot_test_results
+from .plot_scatter import plot_scatter
+from .plot_timeseries import plot_timeseries
+from .plot_test_results import plot_test_results

--- a/pecos/io/__init__.py
+++ b/pecos/io/__init__.py
@@ -2,9 +2,9 @@
 The IO module contains functions to read/send data and write results to files/html reports.
 """
 
-from read_campbell_scientific import read_campbell_scientific
-from send_email import send_email
-from write_monitoring_report import write_monitoring_report
-from write_metrics import write_metrics
-from write_test_results import write_test_results
-from write_dashboard import write_dashboard
+from .read_campbell_scientific import read_campbell_scientific
+from .send_email import send_email
+from .write_monitoring_report import write_monitoring_report
+from .write_metrics import write_metrics
+from .write_test_results import write_test_results
+from .write_dashboard import write_dashboard

--- a/pecos/io/read_campbell_scientific.py
+++ b/pecos/io/read_campbell_scientific.py
@@ -6,20 +6,20 @@ logger = logging.getLogger(__name__)
 def read_campbell_scientific(file_name, index_col='TIMESTAMP', encoding=None):
     """
     Read Campbell Scientific CSV file
-    
+
     Parameters
     ----------
     file_name : string
         File name with full path
-        
+
     index_col : string
         Index column name
-    
+
     encoding : string
         character encoding (i.e. utf-16)
     """
     logger.info("Reading Campbell Scientific CSV file " + file_name)
-    
+
     try:
         df = pd.read_csv(file_name, skiprows=1, encoding=encoding, index_col=index_col, parse_dates=True, dtype=unicode) #, low_memory=False)
         df = df[2:]
@@ -29,13 +29,13 @@ def read_campbell_scientific(file_name, index_col='TIMESTAMP', encoding=None):
         df = pd.DataFrame(data = df.values, index = index, columns = df.columns, dtype='float64')
     except:
         logger.warning("Cannot extract database, CSV file reader failed " + file_name)
-        df = pd.Dataframe()
+        df = pd.DataFrame()
         return
-    
+
     # Drop rows with NaT (not a time) in the index
     try:
         df.drop(pd.NaT, inplace=True)
     except:
         pass
-    
+
     return df

--- a/pecos/logger/__init__.py
+++ b/pecos/logger/__init__.py
@@ -1,1 +1,1 @@
-from logger import initialize
+from .logger import initialize

--- a/pecos/metrics/__init__.py
+++ b/pecos/metrics/__init__.py
@@ -1,2 +1,2 @@
-from qci import qci
-from pv import ac_performance_ratio, clearness_index
+from .qci import qci
+from .pv import ac_performance_ratio, clearness_index

--- a/pecos/monitoring/__init__.py
+++ b/pecos/monitoring/__init__.py
@@ -1,1 +1,1 @@
-from PerformanceMonitoring import PerformanceMonitoring
+from .PerformanceMonitoring import PerformanceMonitoring

--- a/pecos/tests/test_PerformanceMonitoring.py
+++ b/pecos/tests/test_PerformanceMonitoring.py
@@ -93,7 +93,7 @@ def test_check_missing():
 3  Missing data
     """
     expected = [10,5,10,5]
-    print temp['Timesteps']
+    print(temp['Timesteps'])
     assert_items_equal(temp['Timesteps'], expected)
 
 def test_check_corrupt():

--- a/pecos/tests/test_PerformanceMonitoring.py
+++ b/pecos/tests/test_PerformanceMonitoring.py
@@ -16,10 +16,10 @@ trans = {
 
 composite_signals = [
 {'Comp1 (R-sum(M))/R': 'np.divide(({Range} - {Missing}.sum(axis=1)),{Range})'},
-{'Comp2 M*D^2': '{Missing}*np.power({Deviation},2)'}, 
+{'Comp2 M*D^2': '{Missing}*np.power({Deviation},2)'},
 {'Comp3 mean(ALL)-10': '({All}).mean(axis=1) - 10'}]
 
-file_date = [datetime.datetime(2014,01,01,0,0,0)]
+file_date = [datetime.datetime(2014, 1, 1, 0, 0, 0)]
 
 def test_check_timestamp():
     system_name = 'TEST_db1'
@@ -32,24 +32,24 @@ def test_check_timestamp():
     pm.check_timestamp(3600) # 1 hour data
     """
   System Name Variable Name          Start Date            End Date  \
-0                           2014-01-01 04:00:00 2014-01-01 03:00:00   
-1                           2014-01-02 10:00:00 2014-01-02 10:00:00   
-2                           2014-01-02 20:00:00 2014-01-02 20:00:00   
-3                           2014-01-01 03:00:00 2014-01-01 03:00:00   
-4                           2014-01-01 04:00:00 2014-01-01 04:00:00   
-5                           2014-01-01 18:00:00 2014-01-01 18:00:00   
-6                           2014-01-01 02:00:00 2014-01-01 02:00:00   
-7                           2014-01-02 15:00:00 2014-01-02 17:00:00   
+0                           2014-01-01 04:00:00 2014-01-01 03:00:00
+1                           2014-01-02 10:00:00 2014-01-02 10:00:00
+2                           2014-01-02 20:00:00 2014-01-02 20:00:00
+3                           2014-01-01 03:00:00 2014-01-01 03:00:00
+4                           2014-01-01 04:00:00 2014-01-01 04:00:00
+5                           2014-01-01 18:00:00 2014-01-01 18:00:00
+6                           2014-01-01 02:00:00 2014-01-01 02:00:00
+7                           2014-01-02 15:00:00 2014-01-02 17:00:00
 
-   Timesteps              Error Flag  
-0        2.0  Nonmonotonic timestamp  
-1        1.0  Nonmonotonic timestamp  
-2        1.0  Nonmonotonic timestamp  
-3        1.0     Duplicate timestamp  
-4        1.0     Duplicate timestamp  
-5        2.0     Duplicate timestamp  
-6        1.0       Missing timestamp  
-7        3.0       Missing timestamp 
+   Timesteps              Error Flag
+0        2.0  Nonmonotonic timestamp
+1        1.0  Nonmonotonic timestamp
+2        1.0  Nonmonotonic timestamp
+3        1.0     Duplicate timestamp
+4        1.0     Duplicate timestamp
+5        2.0     Duplicate timestamp
+6        1.0       Missing timestamp
+7        3.0       Missing timestamp
     """
     assert_equal(sum(pm.test_results['Error Flag'] == 'Nonmonotonic timestamp'), 3)
     assert_equal(sum(pm.test_results['Error Flag'] == 'Duplicate timestamp'), 3)
@@ -63,39 +63,39 @@ def test_check_missing():
     pm = pecos.monitoring.PerformanceMonitoring()
     pm.add_dataframe(df, system_name)
     pm.add_translation_dictonary(trans, system_name)
-    
+
     pm.check_missing()
-    
+
     temp = pm.test_results[pm.test_results['Error Flag'] == 'Missing data']
-    """  
+    """
   System Name      Variable Name  \
-0              TEST_db1:Missing1   
-1              TEST_db1:Missing2   
-2              TEST_db1:M1*D^2     
-3              TEST_db1:M2*D^2     
+0              TEST_db1:Missing1
+1              TEST_db1:Missing2
+2              TEST_db1:M1*D^2
+3              TEST_db1:M2*D^2
 
            Start Date  \
-0 2014-01-01 06:00:00   
-1 2014-01-02 08:00:00   
-2 2014-01-01 06:00:00   
-3 2014-01-02 08:00:00   
+0 2014-01-01 06:00:00
+1 2014-01-02 08:00:00
+2 2014-01-01 06:00:00
+3 2014-01-02 08:00:00
 
              End Date  Timesteps  \
-0 2014-01-01 15:00:00  10          
-1 2014-01-02 12:00:00  5           
-2 2014-01-01 15:00:00  10          
-3 2014-01-02 12:00:00  5           
+0 2014-01-01 15:00:00  10
+1 2014-01-02 12:00:00  5
+2 2014-01-01 15:00:00  10
+3 2014-01-02 12:00:00  5
 
-     Error Flag  
-0  Missing data  
-1  Missing data  
-2  Missing data  
+     Error Flag
+0  Missing data
+1  Missing data
+2  Missing data
 3  Missing data
     """
     expected = [10,5,10,5]
     print temp['Timesteps']
     assert_items_equal(temp['Timesteps'], expected)
-    
+
 def test_check_corrupt():
     system_name = 'TEST_db1'
     file_name = join(datadir,'TEST_db1_2014_01_01.dat')
@@ -103,12 +103,12 @@ def test_check_corrupt():
     pm = pecos.monitoring.PerformanceMonitoring()
     pm.add_dataframe(df, system_name)
     pm.add_translation_dictonary(trans, system_name)
-    
+
     pm.check_timestamp(3600)
     pm.check_corrupt([-999])
-    
+
     temp = pm.test_results[pm.test_results['Error Flag'] == 'Corrupt data']
-    
+
     """
       System Name       Variable Name          Start Date            End Date Timesteps    Error Flag
 0              TEST_db1:Corrupt1 2014-01-01 11:00:00 2014-01-01 11:00:00         1  Corrupt Data
@@ -116,7 +116,7 @@ def test_check_corrupt():
     """
     expected = [1,2]
     assert_items_equal(temp['Timesteps'], expected)
-    
+
 def test_check_range():
     system_name = 'TEST_db1'
     file_name = join(datadir,'TEST_db1_2014_01_01.dat')
@@ -124,9 +124,9 @@ def test_check_range():
     pm = pecos.monitoring.PerformanceMonitoring()
     pm.add_dataframe(df, system_name)
     pm.add_translation_dictonary(trans, system_name)
-    
+
     pm.check_range([1,3],'Range')
-    
+
     assert_equal(pm.test_results.shape[0], 6)
     assert_equal(sum(pm.test_results['Timesteps']), 11)
     assert_equal(set(pm.test_results['Variable Name']), set(['Range1', 'Range2']))
@@ -138,25 +138,25 @@ def test_check_range():
 #    pm = pecos.monitoring.PerformanceMonitoring()
 #    pm.add_dataframe(df, system_name)
 #    pm.add_translation_dictonary(trans, system_name)
-#    
+#
 #    pm.check_corrupt([-999])
-#        
+#
 #    for composite_signal in composite_signals:
 #        for key,value in composite_signal.items():
 #            signal = pm.evaluate_string(key, value)
 #            pm.add_signal(key, signal)
-#        
+#
 #    error = max(pm.df['TEST_db1:(R1-sum(M))/R1'] - pm.df['Comp1 (R-sum(M))/R 1'])
 #    assert_greater(0.01, error)
 #    error = max(pm.df['TEST_db1:(R2-sum(M))/R2'] - pm.df['Comp1 (R-sum(M))/R 2'])
 #    assert_greater(0.01, error)
-#    error = max(pm.df['TEST_db1:M1*D^2'] - pm.df['Comp2 M*D^2 1']) 
+#    error = max(pm.df['TEST_db1:M1*D^2'] - pm.df['Comp2 M*D^2 1'])
 #    assert_greater(0.01, error)
 #    error = max(pm.df['TEST_db1:M2*D^2'] - pm.df['Comp2 M*D^2 2'])
 #    assert_greater(0.01, error)
 #    error = max(pm.df['TEST_db1:mean(All)-10'] - pm.df['Comp3 mean(ALL)-10'])
 #    assert_greater(0.01, error)
-    
+
 if __name__ == '__main__':
     #test_check_timestamp()
     #test_check_missing()

--- a/pecos/utils/__init__.py
+++ b/pecos/utils/__init__.py
@@ -1,2 +1,2 @@
-from convert_html_to_image import convert_html_to_image
-from round_index import round_index
+from .convert_html_to_image import convert_html_to_image
+from .round_index import round_index


### PR DESCRIPTION
Here's how I fixed the ImportError on Python 3. Python 3 has stricter rules about importing modules, which is generally a good thing. I made a few other quick syntax changes to make a couple of tests run. I also checked that these changes don't break anything for Python 2. I'm not sure why the Python 3 tests are still failing, but at least it's some progress.