### PR TITLE
doc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 *.pyc
+_build/

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -16,19 +16,6 @@ import sys
 import os
 import shlex
 
-# Mock modules so RTD works
-try:
-    from mock import Mock as MagicMock
-except ImportError:
-    from unittest.mock import MagicMock
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return Mock()
-
-MOCK_MODULES = []
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
     
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -33,7 +33,7 @@ sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration ------------------------------------------------
 

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -163,7 +163,7 @@ else:
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-html_style = 'pecos.css'
+#html_style = 'pecos.css'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
I think that this should get your docs working on RTD. One issue is that RTD doesn't actually install pecos, so you have to add the package to the system path (relative to the conf.py path). Another issue is that your css file is causing some kind of problem with the RTD formatting, but I don't know why. 

Regarding the Mock stuff... It used to be that you could not install non-pure-python packages (like numpy) on RTD, so you had to "Mock" them. Now that you can install them on RTD (via your documentation/environment.yml file) the Mock list is empty and thus it's not actually doing anything. So, you can delete all of the mock stuff. I forgot to remove it from pvlib when I reconfigured its documentation a few months ago... sorry for the bad example.

http://wholmgren-pecos.readthedocs.org/en/docfix/